### PR TITLE
Correct link, changed message

### DIFF
--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -126,6 +126,7 @@ layout: default
 <div class="small-12 large-6 columns">
     <div class="meet-block data-block">
     <h3>Public events with your candidates in {{ page.constituency.mapit.name }}</h3>
+    <p class="info"><a href="http://meetyournextmp.com/linktoseat.html?mapitid={{ page.constituency.mapit.id }}">MeetYourNextMP.com</a> lists independent events in your area. Go and question your candidates!</p>
     {% if page.constituency contains 'meet' %}
     <ul class="meet-list">
     {% for event in page.constituency.meet %}
@@ -140,9 +141,9 @@ layout: default
     </ul>
     {% else %}
     <p>
-      We don't know about any events here yet.
+      Sorry, we don't know about any events here.
       Can you add any you know about to 
-      <a href="http://meetyournextmp.com/area/{{ page.constituency.mapit.id }}">MeetYourNextMP.com</a>?
+      <a href="http://meetyournextmp.com/linktoseat.html?mapitid={{ page.constituency.mapit.id }}">MeetYourNextMP.com</a>?
     </p>
     {% endif %}
     </div>


### PR DESCRIPTION
Removed "Yet" because unlike any other DC site, the info we have goes out of date fast. Someone may look at a seat and see "no events yet" where as actually they have already missed 10 events. This is especally true in last week before vote.

In a future commit, I want to add the number of past events to.
