### PR TITLE
Reword numbers page (since locking)

### DIFF
--- a/numbers/index.html
+++ b/numbers/index.html
@@ -5,9 +5,8 @@ hero: Reports
 
 <div class="container">
   <ul class="total_percent">
-      <li>Percent done compared to 2010: {{ site.data.ynmp_numbers.percent_of_2010|round }}%</li>
-      <li>2010 candidates known: {{ site.data.ynmp_numbers.candidates_2010|intcomma }}</li>
-      <li>2015 candidates known: {{ site.data.ynmp_numbers.candidates_2015|intcomma }}</li>
+      <li>Total 2010 candidates: {{ site.data.ynmp_numbers.candidates_2010|intcomma }}</li>
+      <li>Total 2015 candidates: {{ site.data.ynmp_numbers.candidates_2015|intcomma }}</li>
       <li>New candidates: {{ site.data.ynmp_numbers.new_candidates|intcomma }}</li>
       <li>Candidates standing again: {{ site.data.ynmp_numbers.standing_again|intcomma }}</li>
       <li>Candidates standing again for the same party: {{ site.data.ynmp_numbers.standing_again_same_party|intcomma }}</li>


### PR DESCRIPTION
“% done compared to 2010” isn’t really a useful metric anymore. This was just to give an approximation of the correct number of candidates. We now know this number (subject to errors / withdrawals).

Similarly, I don’t think we should talk about # candidates known / not known. I think we can simply refer to these as totals.
