### PR TITLE
Use the scaled and cached image on candidate pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,7 +14,7 @@
           {% if page.person %}
           <div class="person__hero">
             {% if page.person.image %}
-            <img class="person-avatar" src="{{ page.person.image }}"/>
+            <img class="person-avatar" src="{{ page.person.proxy_image }}/0/80"/>
             {% endif %}
             <h1>{{ page.person.name }}</h1>
               <p>Candidate for


### PR DESCRIPTION
The site was previously downloading the full sized image on candidate
pages; not only will this be slow and use a lot of bandwidth, currently
those images aren't cached properly by Varnish, so put unnecessary load
on the server.  This commit changes the candidate pages to use a
thumbnail generated by the image proxy.
