### PR TITLE
Split up person links into DC/contact/websites

### DIFF
--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -24,14 +24,33 @@ layout: default
           <span class="party">{{ person.candidacies['ge2015'].party.name }}</span>
         </div>
 
-        <div class="person-links">
+        {% if person.cv or person.leaflets %}
+        <div class="person-dc-links">
+            <ul>
+            {% if person.cv %}
+            <li><a href='http://cv.democracyclub.org.uk/show_cv/{{ person.id }}'><i class="fa fa-file-text"></i> Curriculum Vitae</a></li>
+            {% endif %}
+            {% if person.leaflets %}
+            {% assign num_leaflets = person.leaflets | size %}
+            <li><a href='/person/{{ person.id }}/{{ person.name|slugify }}'><i class="fa fa-paper-plane"></i> {{ num_leaflets }} leaflet{% if num_leaflets > 1 %}s{% endif %}</a></li>
+            {% endif %}
+            </ul>
+        </div>
+        {% endif %}
+
+        <div class="person-contact-links">
             <ul>
             {% if person.email %}
             <li><a href='mailto:{{ person.email }}'><i class="fa fa-envelope"></i> Email</a></li>
             {% endif %}
-            {% if person.cv %}
-            <li><a href='http://cv.democracyclub.org.uk/show_cv/{{ person.id }}'><i class="fa fa-file-text"></i> Curriculum Vitae</a></li>
+            {% if person.contact_details['twitter'] %}
+            <li><a href='https://twitter.com/{{ person.contact_details['twitter'].value }}'><i class="fa fa-twitter"></i> Twitter account</a></li>
             {% endif %}
+            </ul>
+        </div>
+        
+        <div class="person-web-links">
+            <ul>
             {% if person.links['homepage'] %}
             <li><a href='{{ person.links['homepage'].url }}'><i class="fa fa-home"></i> Homepage</a></li>
             {% endif %}
@@ -49,9 +68,6 @@ layout: default
             {% endif %}
             {% if person.links['linkedin'] %}
             <li><a href='{{ person.links['linkedin'].url }}'><i class="fa fa-linkedin"></i> Linkedin profile</a></li>
-            {% endif %}
-            {% if person.contact_details['twitter'] %}
-            <li><a href='https://twitter.com/{{ person.contact_details['twitter'].value }}'><i class="fa fa-twitter"></i> Twitter account</a></li>
             {% endif %}
             </ul>
         </div>

--- a/_sass/candidates/_people.scss
+++ b/_sass/candidates/_people.scss
@@ -86,8 +86,10 @@
     }
   }
 
-  .person-links {
+  .person-contact-links, .person-web-links, .person-dc-links {
     margin-left: 5.5rem;
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
 
     ul {
       list-style: none;
@@ -97,8 +99,8 @@
       li {
 
         a {
-          &:visited {
-            color: $primary-color;
+          &:link, &:visited {
+            color: #008CBA;
           }
 
           i.fa {


### PR DESCRIPTION
Based on feedback in user testing, it seems that it should be more obvious when we have interesting information about a candidate, such as their CV or some leaflets. I also wanted to split out links that are more for contacting and links which are more websites.

![image](https://cloud.githubusercontent.com/assets/103349/7372773/8b9da150-edc0-11e4-9ca0-dd6851772ea0.png)
![image](https://cloud.githubusercontent.com/assets/103349/7372793/9e4e6a1e-edc0-11e4-9446-2c9144f85e24.png)
