### PR TITLE
Improve candidate name consistency on constituency page

### DIFF
--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -88,15 +88,18 @@ layout: default
       {% for cv in page.constituency.cv %}
         {% assign person = site.data.people.id[cv.person_id] %}
         <li class="cvs-list__cv">
-          <figure>
-            <a href="http://cv.democracyclub.org.uk/show_cv/{{ cv.person_id }}">
+          <a href="http://cv.democracyclub.org.uk/show_cv/{{ cv.person_id }}">
+            <figure>
+              <figcaption class="person-name-and-party">
+                {{ person.name }}
+                <span class="party">{{ person.candidacies.ge2015.party.name }}</span>
+              </figcaption>
               <img src="{{ cv.thumb.url }}">
-            </a>
-            <figcaption class="person-name-and-party">
-              <a href="/person/{{ person.id}}/{{person.name|slugify }}">{{ person.name }}</a>
-              <span class="party">{{ person.candidacies.ge2015.party.name }}</span>
-            </figcaption>
-          </figure>
+              <span class="cvs-list__cv__cta">
+                <span class="button button-radius">Read CV</span>
+              </span>
+            </figure>
+          </a>
         </li>
       {% endfor %}
       </ul>
@@ -124,36 +127,37 @@ layout: default
 
     <p class="info"><a href="https://electionleaflets.org/">ElectionLeaflets.org</a> is an online archive of political leaflets. It is created by members of the public photographing and classifying what comes through their doors at election time.</p>
 
-    {% if page.constituency contains 'el' %}
+  {% if page.constituency contains 'el' %}
     <ul class="leaflets-list">
-    {% for leaflet in page.constituency.el %}
-      <li class="leaflet-list__cv">
-      <figure>
-        <a href="https://electionleaflets.org/leaflets/{{ leaflet.pk }}/">
-          <img src="{{ leaflet.first_page_thumb }}">
-        </a>
-        {% if leaflet.publisher_person %}
-        <figcaption>
-          Sent by {{ leaflet.publisher_person.name }}
-        </figcaption>
-        {% endif %}
-      </figure>
-      </li>
-    {% endfor %}
+      {% for leaflet in page.constituency.el %}
+        <li class="leaflet-list__cv">
+        <figure>
+          <a href="https://electionleaflets.org/leaflets/{{ leaflet.pk }}/">
+            <img src="{{ leaflet.first_page_thumb }}">
+          </a>
+          {% if leaflet.publisher_person %}
+          <figcaption>
+            Sent by {{ leaflet.publisher_person.name }}
+          </figcaption>
+          {% endif %}
+        </figure>
+        </li>
+      {% endfor %}
     </ul>
     <p>
-      <a href="https://electionleaflets.org/constituencies/{{page.constituency.mapit.id}}/{{page.constituency.mapit.name|slugify}}">See more leaflets on ElectionLeaflets.org</a>
+      <a href="https://electionleaflets.org/constituencies/{{page.constituency.mapit.id}}/{{page.constituency.mapit.name|slugify}}" class="button success">See more leaflets on ElectionLeaflets.org</a>
+      <a href="https://electionleaflets.org" class="button secondary">
+        Or add a new leaflet
+      </a>
     </p>
-    {% else %}
+  {% else %}
     <p>
       No one has uploaded any leaflets in {{ page.constituency.mapit.name }} yet.
     </p>
-    {% endif %}
     <p>
-      <a href="https://electionleaflets.org" class="button success">
-        Upload a leaflet
-      </a>
+      <a href="https://electionleaflets.org" class="button success">Add a leaflet you have received</a>
     </p>
+  {% endif %}
     </div>
   </div>
 </div>

--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -28,11 +28,11 @@ layout: default
         <div class="person-dc-links">
             <ul>
             {% if person.cv %}
-            <li><a href='http://cv.democracyclub.org.uk/show_cv/{{ person.id }}'><i class="fa fa-file-text"></i> Curriculum Vitae</a></li>
+            <li><a href='http://cv.democracyclub.org.uk/show_cv/{{ person.id }}'><i class="fa fa-file-text"></i>Curriculum Vitae</a></li>
             {% endif %}
             {% if person.leaflets %}
             {% assign num_leaflets = person.leaflets | size %}
-            <li><a href='/person/{{ person.id }}/{{ person.name|slugify }}'><i class="fa fa-paper-plane"></i> {{ num_leaflets }} leaflet{% if num_leaflets > 1 %}s{% endif %}</a></li>
+            <li><a href='/person/{{ person.id }}/{{ person.name|slugify }}'><i class="fa fa-paper-plane"></i>{{ num_leaflets }} leaflet{% if num_leaflets > 1 %}s{% endif %}</a></li>
             {% endif %}
             </ul>
         </div>
@@ -41,33 +41,33 @@ layout: default
         <div class="person-contact-links">
             <ul>
             {% if person.email %}
-            <li><a href='mailto:{{ person.email }}'><i class="fa fa-envelope"></i> Email</a></li>
+            <li><a href='mailto:{{ person.email }}'><i class="fa fa-envelope"></i>Email</a></li>
             {% endif %}
             {% if person.contact_details['twitter'] %}
-            <li><a href='https://twitter.com/{{ person.contact_details['twitter'].value }}'><i class="fa fa-twitter"></i> Twitter account</a></li>
+            <li><a href='https://twitter.com/{{ person.contact_details['twitter'].value }}'><i class="fa fa-twitter"></i>Twitter account</a></li>
             {% endif %}
             </ul>
         </div>
-        
+
         <div class="person-web-links">
             <ul>
             {% if person.links['homepage'] %}
-            <li><a href='{{ person.links['homepage'].url }}'><i class="fa fa-home"></i> Homepage</a></li>
+            <li><a href='{{ person.links['homepage'].url }}'><i class="fa fa-home"></i>Homepage</a></li>
             {% endif %}
             {% if person.links['party_PPC_page'] %}
-            <li><a href='{{ person.links['party_PPC_page'].url }}'><i class="fa fa-user"></i> Party profile</a></li>
+            <li><a href='{{ person.links['party_PPC_page'].url }}'><i class="fa fa-user"></i>Party profile</a></li>
             {% endif %}
             {% if person.links['wikipedia'] %}
-            <li><a href='{{ person.links['wikipedia'].url }}'><i class='wikipedia-icon'/></i> Wikipedia article</a></li>
+            <li><a href='{{ person.links['wikipedia'].url }}'><i class='wikipedia-icon'/></i>Wikipedia article</a></li>
             {% endif %}
             {% if person.links['facebook_page'] %}
-            <li><a href='{{ person.links['facebook_page'].url }}'><i class="fa fa-facebook-square"></i> Facebook page</a></li>
+            <li><a href='{{ person.links['facebook_page'].url }}'><i class="fa fa-facebook-square"></i>Facebook page</a></li>
             {% endif %}
             {% if person.links['facebook_personal'] %}
-            <li><a href='{{ person.links['facebook_personal'].url }}'><i class="fa fa-facebook-square"></i> Facebook profile</a></li>
+            <li><a href='{{ person.links['facebook_personal'].url }}'><i class="fa fa-facebook-square"></i>Facebook profile</a></li>
             {% endif %}
             {% if person.links['linkedin'] %}
-            <li><a href='{{ person.links['linkedin'].url }}'><i class="fa fa-linkedin"></i> Linkedin profile</a></li>
+            <li><a href='{{ person.links['linkedin'].url }}'><i class="fa fa-linkedin"></i>Linkedin profile</a></li>
             {% endif %}
             </ul>
         </div>

--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -84,10 +84,10 @@ layout: default
     <p class="info">Sending a CV is usually the very first step of a job application, so <a href="http://cv.democracyclub.org.uk/">Democracy Club CVs</a> is collecting every MP candidate's CV</p>
 
     {% if page.constituency contains 'cv' %}
-      <ul class="cvs-list">
+      <ul class="media-list">
       {% for cv in page.constituency.cv %}
         {% assign person = site.data.people.id[cv.person_id] %}
-        <li class="cvs-list__cv">
+        <li class="media-list__item">
           <a href="http://cv.democracyclub.org.uk/show_cv/{{ cv.person_id }}">
             <figure>
               <figcaption class="person-name-and-party">
@@ -95,7 +95,7 @@ layout: default
                 <span class="party">{{ person.candidacies.ge2015.party.name }}</span>
               </figcaption>
               <img src="{{ cv.thumb.url }}">
-              <span class="cvs-list__cv__cta">
+              <span class="media-list__item__cta">
                 <span class="button button-radius">Read CV</span>
               </span>
             </figure>
@@ -128,19 +128,22 @@ layout: default
     <p class="info"><a href="https://electionleaflets.org/">ElectionLeaflets.org</a> is an online archive of political leaflets. It is created by members of the public photographing and classifying what comes through their doors at election time.</p>
 
   {% if page.constituency contains 'el' %}
-    <ul class="leaflets-list">
+    <ul class="media-list">
       {% for leaflet in page.constituency.el %}
-        <li class="leaflet-list__cv">
-        <figure>
-          <a href="https://electionleaflets.org/leaflets/{{ leaflet.pk }}/">
-            <img src="{{ leaflet.first_page_thumb }}">
-          </a>
-          {% if leaflet.publisher_person %}
-          <figcaption>
-            Sent by {{ leaflet.publisher_person.name }}
-          </figcaption>
-          {% endif %}
-        </figure>
+        <li class="media-list__item">
+            <a href="https://electionleaflets.org/leaflets/{{ leaflet.pk }}/">
+                <figure>
+                  {% if leaflet.publisher_person %}
+                    <figcaption class="person-name-and-party">
+                      {{ leaflet.publisher_person.name }}
+                    </figcaption>
+                  {% endif %}
+                    <img src="{{ leaflet.first_page_thumb }}">
+                    <span class="media-list__item__cta">
+                        <span class="button button-radius">Read leaflet</span>
+                    </span>
+                </figure>
+            </a>
         </li>
       {% endfor %}
     </ul>

--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -92,7 +92,7 @@ layout: default
             <a href="http://cv.democracyclub.org.uk/show_cv/{{ cv.person_id }}">
               <img src="{{ cv.thumb.url }}">
             </a>
-            <figcaption class="cv__person-name-and-party">
+            <figcaption class="person-name-and-party">
               <a href="/person/{{ person.id}}/{{person.name|slugify }}">{{ person.name }}</a>
               <span class="party">{{ person.candidacies.ge2015.party.name }}</span>
             </figcaption>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -106,11 +106,10 @@ layout: default
 
     <p class='person__cv__text'>
         {{ page.person.name}} has sent us {{ page.person.gender|pronoun:"possessive" }} CV.
-
-        <a href="http://cv.democracyclub.org.uk/show_cv/{{ page.person.id }}">
-        Read {{ page.person.name}}'s CV now.
-        </a>
     </p>
+    <a class='button' href="http://cv.democracyclub.org.uk/show_cv/{{ page.person.id }}">
+        Read {{ page.person.name}}'s CV now
+    </a>
     <div style='clear:both;'></div>
   {% else %}
     <p class='person__cv__text'>{{ page.person.name }} hasn't sent us {{ page.person.gender|pronoun:"possessive" }} CV.</p>

--- a/_layouts/person.html
+++ b/_layouts/person.html
@@ -123,17 +123,20 @@ layout: default
   <span class='person__box__byline'>by <a href='https://www.electionleaflets.org/'>ElectionLeaflets.org</a></span>
   <h2><i class='fa fa-paper-plane-o'></i> Leaflets</h2>
   {% if page.person.leaflets %}
-  <ul class="leaflets-list">
-    {% for leaflet in page.person.leaflets %}
-      <li class="leaflet-list__cv">
-      <figure>
-        <a href="https://electionleaflets.org/leaflets/{{ leaflet.pk }}/">
-          <img src="{{ leaflet.first_page_thumb }}">
-        </a>
-      </figure>
-      </li>
-    {% endfor %}
-  </ul>
+      <ul class="media-list">
+      {% for leaflet in page.person.leaflets %}
+        <li class="media-list__item">
+            <a href="https://electionleaflets.org/leaflets/{{ leaflet.pk }}/">
+                <figure>
+                    <img src="{{ leaflet.first_page_thumb }}">
+                    <span class="media-list__item__cta">
+                        <span class="button button-radius">Read leaflet</span>
+                    </span>
+                </figure>
+            </a>
+        </li>
+      {% endfor %}
+    </ul>
   {% else %}
     <p>We don't know of any leaflets from {{ page.person.name }}.</p>
   {% endif %}

--- a/_sass/candidates/_cvs.scss
+++ b/_sass/candidates/_cvs.scss
@@ -21,19 +21,53 @@
 .cvs-list__cv {
   list-style-type: none;
   margin-bottom: 1em;
-  @include clearfix;
 
   figure {
     margin: 0;
   }
 
-  .cv__person-name-and-party {
-    font-size: 1.2em;
+  a {
+    display: block;
+    position: relative;
+    border: 1px solid #ddd;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.1);
+    border-radius: 3px;
 
-    .party {
-      @extend %candidate-party;
-      margin-left: 0.0em;
+    &:hover,
+    &:focus {
+      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+      top: -2px;
+      text-decoration: none;
+    }
+  }
+
+  img {
+    min-height: 100px;
+    border-radius: 3px;
+  }
+
+  .person-name-and-party {
+    padding: 0.6em 0.8em;
+    border-bottom: 1px solid #ddd;
+
+    & + img {
+      border-radius: 0 0 3px 3px;
     }
   }
 }
 
+.cvs-list__cv__cta {
+  display: block;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2em 0;
+  text-align: center;
+  @include linear-gradient(transparent, #fff);
+  border-radius: 0 0 3px 3px;
+
+  .button {
+    margin-bottom: 0;
+  }
+}

--- a/_sass/candidates/_cvs.scss
+++ b/_sass/candidates/_cvs.scss
@@ -1,4 +1,4 @@
-.cvs-list {
+.media-list {
   margin: 1.5em 0;
 
   @media #{$small-up} {
@@ -18,7 +18,7 @@
   }
 }
 
-.cvs-list__cv {
+.media-list__item {
   list-style-type: none;
   margin-bottom: 1em;
 
@@ -32,6 +32,7 @@
     border: 1px solid #ddd;
     box-shadow: 0 1px 1px rgba(0,0,0,0.1);
     border-radius: 3px;
+    overflow: hidden;
 
     &:hover,
     &:focus {
@@ -43,20 +44,16 @@
 
   img {
     min-height: 100px;
-    border-radius: 3px;
+    margin: 0 auto; // centre the image if it's not wide enough
   }
 
   .person-name-and-party {
     padding: 0.6em 0.8em;
     border-bottom: 1px solid #ddd;
-
-    & + img {
-      border-radius: 0 0 3px 3px;
-    }
   }
 }
 
-.cvs-list__cv__cta {
+.media-list__item__cta {
   display: block;
   position: absolute;
   bottom: 0;
@@ -65,7 +62,6 @@
   padding: 2em 0;
   text-align: center;
   @include linear-gradient(transparent, #fff);
-  border-radius: 0 0 3px 3px;
 
   .button {
     margin-bottom: 0;

--- a/_sass/candidates/_leaflets.scss
+++ b/_sass/candidates/_leaflets.scss
@@ -1,38 +1,7 @@
-.leaflets-list {
-  margin: 1.5em 0;
-
-  @media #{$small-up} {
-    @include block-grid(1);
-  }
-
-  @media #{$medium-up} {
-    @include block-grid(2);
-  }
-
-  @media #{$large-up} {
-    @include block-grid(3);
-  }
-
-  li p {
-    margin: 5px 0 0 0;
-  }
-}
-
-.leaflets-list__leaflet {
-  list-style-type: none;
-  margin-bottom: 1em;
-  @include clearfix;
-
-  .leaflet__person-name-and-party {
-    font-size: 1.2em;
-
-    .party {
-      @extend %candidate-party;
-      margin-left: 0.0em;
+.leaflets-block {
+  .media-list__item {
+    img {
+      border: 0.5em solid #fff;
     }
   }
-}
-
-figure {
-    margin: 0;
 }

--- a/_sass/candidates/_mixins.scss
+++ b/_sass/candidates/_mixins.scss
@@ -1,0 +1,8 @@
+@mixin linear-gradient($from, $to){
+  background: -moz-linear-gradient(top, $from 0%, $to 100%);
+  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,$from), color-stop(100%,$to));
+  background: -webkit-linear-gradient(top, $from 0%, $to 100%);
+  background: -o-linear-gradient(top, $from 0%, $to 100%);
+  background: -ms-linear-gradient(top, $from 0%, $to 100%);
+  background: linear-gradient(to bottom, $from 0%, $to 100%);
+}

--- a/_sass/candidates/_people.scss
+++ b/_sass/candidates/_people.scss
@@ -77,15 +77,6 @@
     background-color: #ddd;
   }
 
-  .person-name-and-party {
-    font-size: 1.2em;
-    margin-left: 5.5rem;
-
-    .party {
-      @extend %candidate-party;
-    }
-  }
-
   .person-contact-links, .person-web-links, .person-dc-links {
     margin-left: 5.5rem;
     margin-top: 0.5rem;
@@ -112,14 +103,28 @@
   }
 }
 
-i.wikipedia-icon:before {
-  font-family: 'wikipedia-icon';
-  content: '\e600';
+.person-name-and-party {
+  font-size: 1.2em;
+  line-height: 1.4em;
+
+  .person-avatar + & {
+    margin-left: 5.5rem;
+  }
+
+  .party {
+    @extend %candidate-party;
+  }
 }
 
 i.wikipedia-icon {
-  font-style: normal;
-  padding-right: 0.5rem;
+  display: inline-block;
+  font: normal normal normal 14px/1 'wikipedia-icon'; // shortening font declaration
+  font-size: inherit; // can't have font-size inherit on line above, so need to override
+  vertical-align: text-bottom;
+
+  &:before {
+    content: '\e600';
+  }
 }
 
 .candidates__known {

--- a/_sass/candidates/_people.scss
+++ b/_sass/candidates/_people.scss
@@ -79,24 +79,22 @@
 
   .person-contact-links, .person-web-links, .person-dc-links {
     margin-left: 5.5rem;
-    margin-top: 0.5rem;
-    padding-top: 0.5rem;
+    margin-top: 0.75rem;
 
     ul {
       list-style: none;
       margin: 0;
       padding: 0;
 
-      li {
+      a {
+        &:link, &:visited {
+          color: #008CBA;
+        }
 
-        a {
-          &:link, &:visited {
-            color: #008CBA;
-          }
-
-          i.fa {
-            padding-right: 0.5rem;
-          }
+        i {
+          padding-right: 0.5rem;
+          width: 1.5em; // make sure labels line up after different sized icons
+          text-align: center;
         }
       }
     }
@@ -199,7 +197,7 @@ i.wikipedia-icon {
     float: right;
     width: 35%;
   }
-  
+
   .person__details {
     /*@include grid-column($columns: 5, $pull: 5, $collapse: true);*/
     float: left;
@@ -296,7 +294,7 @@ i.wikipedia-icon {
         margin: 0 0 0.5rem 0;
     }
 }
-    
+
 .person__box__byline {
     float:right;
     font-style:italic;
@@ -325,7 +323,7 @@ i.wikipedia-icon {
 
     .person__cv__text {
     }
-        
+
     .button {
         margin: 0 0 0 0;
     }

--- a/_sass/candidates/style.scss
+++ b/_sass/candidates/style.scss
@@ -22,6 +22,7 @@ $code-font-family: Consolas, Monaco, 'Liberation Mono', Courier, monospace;
 
 @import "../normalize";
 @import "../foundation";
+@import 'mixins';
 
 .container {
   @include grid-row();
@@ -60,7 +61,7 @@ pre {
 }
 
 .magellan_menu {
-  
+
   [data-magellan-expedition] {
     background: #f5f5f5;
 
@@ -68,7 +69,7 @@ pre {
         color: #8c8c8c;
     }
   }
- 
+
   .fixed {
     background: #09a691;
     margin:0;

--- a/_sass/candidates/style.scss
+++ b/_sass/candidates/style.scss
@@ -62,34 +62,49 @@ pre {
 
 .magellan_menu {
 
-  [data-magellan-expedition] {
+  [data-magellan-expedition],
+  [data-magellan-expedition-clone] {
     background: #f5f5f5;
+    padding: 0;
 
     a {
-        color: #8c8c8c;
+      color: #8c8c8c;
+    }
+  }
+
+  .sub-nav {
+    margin: 0 -1em;
+    padding: 0;
+
+    dd {
+      margin: 0;
+
+      a {
+        display: block;
+        padding: 0.5em 1em;
+      }
     }
   }
 
   .fixed {
-    background: #09a691;
     margin:0;
     padding:0;
+    border-bottom: 1px solid #eee;
 
     dl.sub-nav {
-      line-height:2em;
-      width: 100%;
-      margin-left: auto;
-      margin-right: auto;
-      margin-top: 0;
-      margin-bottom: 0;
+      margin: 0 auto;
       max-width: 62.5rem;
-      background: #09a691;
-      color: #fff;
+      background: transparent;
 
-      .active a, a {
-        color: #fff;
-        font-weight: bold;
-        background:none !important;
+      a {
+        color: #8c8c8c;
+        font-weight: normal;
+      }
+
+      .active {
+        a {
+          background: transparent;
+        }
       }
     }
   }


### PR DESCRIPTION
For #60.

Candidate names are now presented in the same way across the page (where possible). Eg, above CVs:

![screen shot 2015-04-29 at 17 10 32](https://cloud.githubusercontent.com/assets/739624/7395600/d2601f00-ee92-11e4-8d66-72d5788bef18.png)

And above leaflets (I couldn't fish the party out, alas):

![screen shot 2015-04-29 at 17 10 45](https://cloud.githubusercontent.com/assets/739624/7395608/da94d882-ee92-11e4-9191-ead9d5e6dbcf.png)

The CVs and leaflets also look a lot more clickable now, after some user testing feedback that they didn't look interactive.

I've also cleaned up the styling of the magellan fixed navbar – although I'm not convinced it actually does the job we want it to. If we had more time, it'd be worth having a much more in-depth look at how we can make it clear you can **scroll down** this page, because I have a feeling most people just stop once they've seen the gap below the last candidate.
