### PR TITLE
Add party logos to candidates in constituency

### DIFF
--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -20,7 +20,7 @@ layout: default
         </a>
 
         {% if person.party_emblem.proxy_url %}
-          <img class="person-avatar" src="{{ person.party_emblem.proxy_url}}/128/0">
+          <img class="person-emblem" src="{{ person.party_emblem.proxy_url}}/128/0">
         {% endif %}
 
         <div class="person-name-and-party">

--- a/_layouts/constituency.html
+++ b/_layouts/constituency.html
@@ -19,6 +19,10 @@ layout: default
         {% endif %}
         </a>
 
+        {% if person.party_emblem.proxy_url %}
+          <img class="person-avatar" src="{{ person.party_emblem.proxy_url}}/128/0">
+        {% endif %}
+
         <div class="person-name-and-party">
           <a href="/person/{{ person.id}}/{{person.name|slugify }}">{{ person.name }}</a>
           <span class="party">{{ person.candidacies['ge2015'].party.name }}</span>

--- a/_sass/candidates/_people.scss
+++ b/_sass/candidates/_people.scss
@@ -90,7 +90,7 @@
   margin-bottom: 1em;
   @include clearfix;
 
-  .person-avatar {
+  .person-avatar, .person-emblem {
     float: left;
     width: 4em;
     height: auto;
@@ -98,19 +98,13 @@
     background-color: #ddd;
   }
   
-  .person-avatar + .person-avatar { // a party emblem!
+  .person-emblem {
      margin-top: 1em;
      clear: left;
      opacity: 0.3;
   }
 
   .person-links, .person-contact-links, .person-web-links, .person-dc-links {
-    margin-left: 5.5rem;
-    margin-top: 0.75rem;
-  }
-
-  .person-name-and-party {
-    font-size: 1.2em;
     margin-left: 5.5rem;
     margin-top: 0.75rem;
   }

--- a/_sass/candidates/_people.scss
+++ b/_sass/candidates/_people.scss
@@ -97,8 +97,20 @@
     margin-right: 1.5em;
     background-color: #ddd;
   }
+  
+  .person-avatar + .person-avatar { // a party emblem!
+     margin-top: 1em;
+     clear: left;
+     opacity: 0.3;
+  }
 
   .person-links, .person-contact-links, .person-web-links, .person-dc-links {
+    margin-left: 5.5rem;
+    margin-top: 0.75rem;
+  }
+
+  .person-name-and-party {
+    font-size: 1.2em;
     margin-left: 5.5rem;
     margin-top: 0.75rem;
   }


### PR DESCRIPTION
The absolute minimal fix for #53.

The page is looking _really busy_ now, but if you want party logos, as per #53, then this is the quickest simplest way to get them on there.

![screen shot 2015-04-29 at 17 30 49](https://cloud.githubusercontent.com/assets/739624/7395970/90829e8e-ee95-11e4-8bf9-f618695f6d88.png)
