### PR TITLE
Link to correct github issue tracker in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="footer__links">
     <p><a href="/help/api">Open data API</a> · <a href="/help/about">About</a> ·
-      <a href="https://github.com/mysociety/yournextmp-popit/issues">Issue tracker</a> ·
+      <a href="https://github.com/DemocracyClub/YourNextMP-Read/issues">Issue tracker</a> ·
       <a href="/help/privacy">Privacy policy</a></p>
   </div>
   <div class="footer__bylines">


### PR DESCRIPTION
Now links to this issue tracker rather than the edit site one.
